### PR TITLE
don't wipe out overloaded functions (and add tests)

### DIFF
--- a/lib/namespace/autoclean.pm
+++ b/lib/namespace/autoclean.pm
@@ -130,7 +130,7 @@ sub import {
             $extra{ $method } = 1;
         }
 
-        my @symbols = keys %{ $meta->get_all_package_symbols('CODE') };
+        my @symbols = grep { !/^\(/ } keys %{ $meta->get_all_package_symbols('CODE') };
         namespace::clean->clean_subroutines($cleanee, keys %extra, grep { !$methods{$_} } @symbols);
     };
 }

--- a/t/overloads.t
+++ b/t/overloads.t
@@ -1,23 +1,11 @@
 #!/usr/bin/perl
 
-=head1 NAME
-
-overloads.t - Make sure we don't klobber overloaded functions
-
-=head1 DESCRIPTION 
-
-This test exercises namespace::autoclean with overloaded operators; making
-sure we don't klobber them.
-
-=cut
-
 {
     package TestOverload;
 
     use Moose;
     use namespace::autoclean;
     use overload '""' => sub { shift->id         }, fallback => 1;
-    use overload '+'  => sub { (shift) + (shift) }, fallback => 1;
 
     has id => (is => 'ro', default => 'bar');
 
@@ -34,10 +22,4 @@ isa_ok $one => 'TestOverload';
 
 is $one->id, 'bar', 'id is "bar"';
 is "$one",   'bar', 'id stringifies to "bar"';
-
-__END__
-
-=head1 AUTHOR
-
-Chris Weyl  <cweyl@alumni.drew.edu>
 

--- a/t/overloads.t
+++ b/t/overloads.t
@@ -1,0 +1,43 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+overloads.t - Make sure we don't klobber overloaded functions
+
+=head1 DESCRIPTION 
+
+This test exercises namespace::autoclean with overloaded operators; making
+sure we don't klobber them.
+
+=cut
+
+{
+    package TestOverload;
+
+    use Moose;
+    use namespace::autoclean;
+    use overload '""' => sub { shift->id         }, fallback => 1;
+    use overload '+'  => sub { (shift) + (shift) }, fallback => 1;
+
+    has id => (is => 'ro', default => 'bar');
+
+    __PACKAGE__->meta->make_immutable;
+}
+
+use strict;
+use warnings;
+
+use Test::More tests => 3;
+
+my $one = TestOverload->new;
+isa_ok $one => 'TestOverload';
+
+is $one->id, 'bar', 'id is "bar"';
+is "$one",   'bar', 'id stringifies to "bar"';
+
+__END__
+
+=head1 AUTHOR
+
+Chris Weyl  <cweyl@alumni.drew.edu>
+


### PR DESCRIPTION
OK, so it's been a couple years since I last took a shot at this, but here goes:  whatever we think of overloads, they're a part of Perl.  While they're not exactly methods, they're "imported symbols" that we probably ought to not purge from the stash, as that's... surprising.

This is a simple change that looks for overload symbols, and removes any found from the "purge these" list.
